### PR TITLE
RHIN-983: changes made to resourceIntro component to incorporate checkbox.

### DIFF
--- a/src/less/resources.less
+++ b/src/less/resources.less
@@ -12,6 +12,7 @@
 @resource-interface-size: 2rem;
 @resource-unread-size: 1rem;
 @resource-icon-size: 1.25em;
+@resource-checkbox-margin: 1.5em;
 @resource-avatar-size: @avatar-size-small;
 
 @resource-interface-active-decrease: 0.6rem;
@@ -296,7 +297,15 @@
 }
 
 .resource__intro__media--icon {
+  &.resource__intro__media--checkbox {
+    margin-right: @resource-checkbox-margin;
+  }
+
   width: @resource-icon-size;
+}
+
+.resource__intro__media--checkbox {
+  width: @resource-checkbox-margin;
 }
 
 .resource__intro__title-wrapper {

--- a/src/scripts/components/ResourceIntro.jsx
+++ b/src/scripts/components/ResourceIntro.jsx
@@ -29,7 +29,7 @@ class ResourceIntro extends React.Component {
                 label={checkbox.label}
                 name={checkbox.name}
                 isChecked={checkbox.isChecked}
-                onClick={checkbox.onClick}
+                onChange={checkbox.onChange}
               />
             }
             <Button reset onClick={this.handleIconClick}>
@@ -45,7 +45,7 @@ class ResourceIntro extends React.Component {
                 label={checkbox.label}
                 name={checkbox.name}
                 isChecked={checkbox.isChecked}
-                onClick={checkbox.onClick}
+                onChange={checkbox.onChange}
               />
             }
             <Icon bump={icon.bump} icon={icon.icon} />
@@ -67,7 +67,7 @@ class ResourceIntro extends React.Component {
           label={checkbox.label}
           name={checkbox.name}
           isChecked={checkbox.isChecked}
-          onClick={checkbox.onClick}
+          onChange={checkbox.onChange}
         />
       );
     }
@@ -137,7 +137,7 @@ ResourceIntro.propTypes = {
     isChecked: PropTypes.bool,
     label: PropTypes.string,
     name: PropTypes.string,
-    onClick: PropTypes.func,
+    onChange: PropTypes.func,
   }),
   children: PropTypes.node,
   title: PropTypes.any,

--- a/src/scripts/components/ResourceIntro.jsx
+++ b/src/scripts/components/ResourceIntro.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cx from 'classnames';
 
-import { Avatar, Button, Icon } from '../components';
+import { Avatar, Button, Checkbox, Icon } from '../components';
 
 class ResourceIntro extends React.Component {
   handleIconClick = (e) => {
@@ -16,19 +16,41 @@ class ResourceIntro extends React.Component {
   }
 
   renderMedia = () => {
-    const { icon, avatar } = this.props;
+    const { icon, avatar, checkbox } = this.props;
     let output = null;
     const validIcon = icon && icon.icon;
 
     if (validIcon) {
       if (icon.onClick) {
         output = (
-          <Button reset onClick={this.handleIconClick}>
-            <Icon bump={icon.bump} icon={icon.icon} />
-          </Button>
+          <div className="u-flex">
+            {checkbox &&
+              <Checkbox
+                label={checkbox.label}
+                name={checkbox.name}
+                isChecked={checkbox.isChecked}
+                onClick={checkbox.onClick}
+              />
+            }
+            <Button reset onClick={this.handleIconClick}>
+              <Icon bump={icon.bump} icon={icon.icon} />
+            </Button>
+          </div>
         );
       } else {
-        output = <Icon bump={icon.bump} icon={icon.icon} />;
+        output = (
+          <div className="u-flex">
+            {checkbox &&
+              <Checkbox
+                label={checkbox.label}
+                name={checkbox.name}
+                isChecked={checkbox.isChecked}
+                onClick={checkbox.onClick}
+              />
+            }
+            <Icon bump={icon.bump} icon={icon.icon} />
+          </div>
+        );
       }
     } else if (avatar) {
       output = (
@@ -39,10 +61,20 @@ class ResourceIntro extends React.Component {
           image={avatar.image}
         />
       );
+    } else if (checkbox) {
+      output = (
+        <Checkbox
+          label={checkbox.label}
+          name={checkbox.name}
+          isChecked={checkbox.isChecked}
+          onClick={checkbox.onClick}
+        />
+      );
     }
 
     if (output) {
       const classes = cx('resource__intro__media', {
+        'resource__intro__media--checkbox': checkbox,
         'resource__intro__media--icon': validIcon,
         'resource__intro__media--hidden@xsmall': this.props.hideMediaXsmall,
       });
@@ -99,6 +131,12 @@ ResourceIntro.propTypes = {
   icon: PropTypes.shape({
     icon: PropTypes.string,
     bump: PropTypes.string,
+    onClick: PropTypes.func,
+  }),
+  checkbox: PropTypes.shape({
+    isChecked: PropTypes.bool,
+    label: PropTypes.string,
+    name: PropTypes.string,
     onClick: PropTypes.func,
   }),
   children: PropTypes.node,

--- a/src/scripts/docs/examples/Resource.example.txt
+++ b/src/scripts/docs/examples/Resource.example.txt
@@ -75,7 +75,7 @@ class ComponentExample extends React.Component {
             </ResourceRight>
           </Resource>
         </ResourceGroup>
-        <ResourceGroup separator="Another example" interfaceMode="checkbox">
+        <ResourceGroup separator="Another example" interfaceMode="radio">
           <Resource>
             <ResourceIntro avatar={{ type: 'member' }} title="Zach Schnackel" />
             <ResourceBody>

--- a/src/scripts/docs/examples/Resource.example.txt
+++ b/src/scripts/docs/examples/Resource.example.txt
@@ -21,6 +21,17 @@ class ComponentExample extends React.Component {
               I'm part of the ResourceBottom component!
             </ResourceBottom>
           </Resource>
+          <Resource unread>
+            <ResourceIntro checkbox={{ name: 'test', label: ' ' }} title="Brendan Dagg" titleSub="Patient">
+              <span className="u-text-accent">Assigned</span>
+            </ResourceIntro>
+            <ResourceBody>
+              You <Icon size="small" icon="arrow-right" /> Some body stuff!Some body stuff!Some body stuff!Some body stuff!Some body stuff!Some body stuff!Some body stuff!Some body stuff!Some body stuff!Some body stuff!Some body stuff!
+            </ResourceBody>
+            <ResourceRight>
+              Just now
+            </ResourceRight>
+          </Resource>
           <Resource active>
             <ResourceIntro icon={{ icon: 'mobile' }} title="This is a really long name that keeps on going" titleSub="(844) 755-0396" />
             <ResourceBody>
@@ -64,7 +75,7 @@ class ComponentExample extends React.Component {
             </ResourceRight>
           </Resource>
         </ResourceGroup>
-        <ResourceGroup separator="Another example" interfaceMode="radio">
+        <ResourceGroup separator="Another example" interfaceMode="checkbox">
           <Resource>
             <ResourceIntro avatar={{ type: 'member' }} title="Zach Schnackel" />
             <ResourceBody>


### PR DESCRIPTION
✔︎ I've tested in all browsers (IE11, Firefox, Safari, Chrome, and iOS)

### What should this PR do?
When **checkbox** is added as props to **resourceIntro** in rhinostyle, a checkbox should be displayed.
https://rhinogram.atlassian.net/browse/RHIN-983

### What is the acceptance criteria?
When **checkbox** is added as props to **resourceIntro** in rhinostyle, a checkbox should be displayed.

[If there are UI changes, include a before and after screenshot.]
when **checkbox is added as props** , it appears as below:

![screen shot 2018-09-27 at 12 41 46 pm](https://user-images.githubusercontent.com/25630095/46128934-c3082d80-c252-11e8-826a-2341ba1d0539.png)
