### PR TITLE
flipped logic concerning hasChartData

### DIFF
--- a/src/scripts/components/Chart.jsx
+++ b/src/scripts/components/Chart.jsx
@@ -55,10 +55,7 @@ class Chart extends React.Component {
   );
 
   render() {
-    let hasData = true;
-    if (typeof this.props.data === 'undefined' || this.props.data === null || Object.keys(this.props.data).length === 0 || this.props.data.datasets.length === 0) {
-      hasData = false;
-    }
+    const hasData = this.props.data && Object.keys(this.props.data).length && this.props.data.datasets && this.props.data.datasets.length;
     return (
       <div className="chart">
         <div className="chart__header">

--- a/src/scripts/components/Chart.jsx
+++ b/src/scripts/components/Chart.jsx
@@ -8,9 +8,6 @@ import { Icon } from '.';
 import Tooltip from './Tooltip';
 
 class Chart extends React.Component {
-  state = {
-    hasChartData: true,
-  };
 
   legendCallback = (chart) => {
     const { labels, datasets } = chart.data;
@@ -26,14 +23,6 @@ class Chart extends React.Component {
     text.push('</ul>');
     return text.join('');
   };
-
-  componentDidMount() {
-    const { data } = this.props;
-    if (typeof data === 'undefined' || data === null || Object.keys(data).length === 0 || data.datasets.length === 0) {
-      this.setState({ hasChartData: false });
-    }
-    this.forceUpdate();
-  }
 
   renderChart = (properties) => {
     const { type } = properties;
@@ -66,6 +55,10 @@ class Chart extends React.Component {
   );
 
   render() {
+    let hasData = true;
+    if (typeof this.props.data === 'undefined' || this.props.data === null || Object.keys(this.props.data).length === 0 || this.props.data.datasets.length === 0) {
+      hasData = false;
+    }
     return (
       <div className="chart">
         <div className="chart__header">
@@ -77,7 +70,7 @@ class Chart extends React.Component {
               </Tooltip>
             )}
           </div>
-          {this.state.hasChartData && this.props.header && this.props.header.text && (
+          {hasData && this.props.header && this.props.header.text && (
             <div className={`header__subtitle ${this.props.header.color}`}>
               {this.props.header.text}
               {this.props.subHeader && (
@@ -88,7 +81,7 @@ class Chart extends React.Component {
             </div>
           )}
         </div>
-        {this.state.hasChartData ? this.renderChart(this.props) : this.renderNoData()}
+        {hasData ? this.renderChart(this.props) : this.renderNoData()}
       </div>
     );
   }

--- a/src/scripts/components/Chart.jsx
+++ b/src/scripts/components/Chart.jsx
@@ -9,7 +9,7 @@ import Tooltip from './Tooltip';
 
 class Chart extends React.Component {
   state = {
-    hasChartData: false,
+    hasChartData: true,
   };
 
   legendCallback = (chart) => {
@@ -30,7 +30,7 @@ class Chart extends React.Component {
   componentDidMount() {
     const { data } = this.props;
     if (typeof data === 'undefined' || data === null || Object.keys(data).length === 0 || data.datasets.length === 0) {
-      this.setState({ hasChartData: true });
+      this.setState({ hasChartData: false });
     }
     this.forceUpdate();
   }
@@ -78,7 +78,7 @@ class Chart extends React.Component {
               </Tooltip>
             )}
           </div>
-          {!this.state.hasChartData && ChartProperties.header && ChartProperties.header.text && (
+          {this.state.hasChartData && ChartProperties.header && ChartProperties.header.text && (
             <div className={`header__subtitle ${ChartProperties.header.color}`}>
               {ChartProperties.header.text}
               {ChartProperties.subHeader && (
@@ -89,7 +89,7 @@ class Chart extends React.Component {
             </div>
           )}
         </div>
-        {this.state.hasChartData ? this.renderNoData() : this.renderChart(ChartProperties)}
+        {this.state.hasChartData ? this.renderChart(ChartProperties) : this.renderNoData()}
       </div>
     );
   }

--- a/src/scripts/components/Chart.jsx
+++ b/src/scripts/components/Chart.jsx
@@ -66,30 +66,29 @@ class Chart extends React.Component {
   );
 
   render() {
-    const { ...ChartProperties } = this.props;
     return (
       <div className="chart">
         <div className="chart__header">
           <div className="header__title">
-            {ChartProperties.title}
-            {ChartProperties.info && (
-              <Tooltip content={ChartProperties.info}>
+            {this.props.title}
+            {this.props.info && (
+              <Tooltip content={this.props.info}>
                 <Icon className="header__icon--info" icon="info-circle" />
               </Tooltip>
             )}
           </div>
-          {this.state.hasChartData && ChartProperties.header && ChartProperties.header.text && (
-            <div className={`header__subtitle ${ChartProperties.header.color}`}>
-              {ChartProperties.header.text}
-              {ChartProperties.subHeader && (
+          {this.state.hasChartData && this.props.header && this.props.header.text && (
+            <div className={`header__subtitle ${this.props.header.color}`}>
+              {this.props.header.text}
+              {this.props.subHeader && (
                 <span className="subtitle--muted">
-                  {ChartProperties.subHeader}
+                  {this.props.subHeader}
                 </span>
               )}
             </div>
           )}
         </div>
-        {this.state.hasChartData ? this.renderChart(ChartProperties) : this.renderNoData()}
+        {this.state.hasChartData ? this.renderChart(this.props) : this.renderNoData()}
       </div>
     );
   }


### PR DESCRIPTION
✔︎ I've tested in all browsers (IE11, Firefox, Safari, Chrome, and iOS)

### What should this PR do?
Adjusted logic for a state property in Chart.jsx that was essentially named backwards.

It's `hasChartData`, but its being used as if its `noChartData`. To keep in convention with how we name bools, I just updated the logic surrounding the variable instead of renaming it. 


I also did away with the abstraction of `this.props` into `ChartProperties`. It caused confusion at first glance (true for another dev as well), so I'd just argue that this abstraction causes more issues than having to read `this.props`. No bugs here, just trying to make this a bit more readable.