### PR TITLE
RHIN-6491 Updating readme for using semver with Github URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,41 +12,30 @@
   * [Gulp](http://gulpjs.com) `yarn global add gulp-cli`
 
 
+---
 ## Development Workflow
 
-## IMPORTANT!
-
+### IMPORTANT!
 Because the build process uses outdated Gulp 3, you must use Node 10. If you have Node 10 installed via Brew, you can use it like:
 ```
-PATH=\"/usr/local/Cellar/node@10/10.23.0/bin/:$PATH\" yarn build
+PATH="/usr/local/opt/node@10/bin:$PATH" yarn build
 ```
 
-Individual gulp tasks can be found in [gulpfile.babel.js](gulpfile.babel.js), but for development you will run:
+Individual gulp tasks are in [gulpfile.babel.js](gulpfile.babel.js), but for development run:
 
-* `gulp serve` Starts BrowserSync instance, watches for file changes, and automatically reloads your browser.
+* `gulp serve` Starts BrowserSync instance, watches for file changes, and automatically reloads your browser
 
-When adding / deleting any of the media, audio, or animation files, it may be necessary to run `gulp build` to capture those changes.
+* If adding / deleting any of the media, audio, or animation files, run `gulp build` to capture the changes
+### Yarn link
+Develop locally without having to push changes to Github using `yarn link`. From the rhinostyle directory, run: `yarn link`. Go to the directory of your project (rhinofront) and run: `yarn link rhinostyle`.
 
+---
 ## Releasing
+Run `yarn build` and commit before creating a new release.
 
-To release a new version of RhinoStyle, commit your changes and create a PR into master. Once merged, the changes will automatically be updated on the live site.
+Once merged into `master`, publish a new release in GitHub following the rules of [semantic versioning](https://semver.org).
 
-After your changes have been merged into master, click on the `releases` tab, then the `Draft a new release` button. Increase the tag number from the previous build, and then press the `Publish Release` button.
-
-In [Rhinofront](https://github.com/rhinogram/rhinofront.git), edit `package.json` to the following:
-```
-"rhinostyle": "https://github.com/rhinogram/rhinostyle.git#<TAG_NUMBER>",
-```
-Test locally to ensure that your changes are coming through, then submit a PR to [Rhinofront](https://github.com/rhinogram/rhinofront.git) with the updated `package.json`.
-
-To run your local version of rhinostyle, use `yarn link`, as follows:
-Go to your rhinostyle folder and run: `yarn link`
-Then go to the folder in your project and run: `yarn link rhinostyle`
-NOTE: that `rhinostyle` must be the name on the `package.json` inside the `rhinostyle` folder
-
-Then you can require your `rhinostyle` code as usual:
-
-
+---
 ## Browser Support
 
 ![Chrome](https://raw.github.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png) | ![Firefox](https://raw.github.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png) | ![Edge](https://raw.github.com/alrra/browser-logos/master/src/edge/edge_48x48.png) | ![IE](https://raw.github.com/alrra/browser-logos/master/src/archive/internet-explorer_9-11/internet-explorer_9-11_48x48.png) | ![Safari](https://raw.github.com/alrra/browser-logos/master/src/safari/safari_48x48.png)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Setup
 
-* Make sure you have the following installed:
+Make sure you have the following installed:
   * [NodeJS](http://nodejs.org) `10.x`
   * [yarn](https://www.npmjs.com/) `>= 0.23.4`
   * [Gulp](http://gulpjs.com) `yarn global add gulp-cli`


### PR DESCRIPTION
**Related Jira link:** [RHIN-6491](https://rhinogram.atlassian.net/browse/RHIN-6491)

### PR Checklist
- [x] I've tested in all browsers (Firefox, Safari, Chrome, Edge, and iOS)

### What should this PR do?
* Updating the readme to reflect how to release new versions of rhinostyle since rhinofront will start to pull all patch and minor version of rhinostyle automatically