### PR TITLE
RHIN-6620 convert deprecated lifecycle method and enable lint for same

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,6 @@
   "rules": {
     "react/state-in-constructor": 0,
     "react/jsx-props-no-spreading": 0,
-    "import/no-cycle": 0, // Temporary
-    "react/no-deprecated": 0 // Temporary
+    "import/no-cycle": 0 // Temporary
   }
 }

--- a/src/scripts/components/DropdownFilter.jsx
+++ b/src/scripts/components/DropdownFilter.jsx
@@ -8,7 +8,8 @@ class DropdownFilter extends React.Component {
     items: this.props.children,
   };
 
-  componentWillReceiveProps() {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps() {
     this.setState({
       items: this.getChildren(),
     });

--- a/src/scripts/components/DropdownMultiSelectAdvanced.jsx
+++ b/src/scripts/components/DropdownMultiSelectAdvanced.jsx
@@ -12,7 +12,6 @@ import {
   UtilitySystem,
   Dropdown,
   UtilityInlineGrid,
-  ResourceRight,
 } from '.';
 
 class DropdownMultiSelectAdvanced extends React.Component {


### PR DESCRIPTION
**Related Jira link:** [RHIN-XXXX](https://rhinogram.atlassian.net/browse/RHIN-XXXX)
https://rhinogram.atlassian.net/browse/RHIN-6620
### PR Checklist
- [ ] I've tested in all browsers (Firefox, Safari, Chrome, Edge, and iOS)

### What should this PR do?
* RHIN-6620 convert deprecated lifecycle method and enable lint for same so that we can upgrade react version to 18

[If there are UI changes, include a before and after screenshot.]
